### PR TITLE
feat: use autoimport for components in posts

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
 		"svelte-check": "^2.9.0",
 		"svelte-preprocess": "^4.10.7",
 		"svelte-preprocess-import-assets": "^0.1.6",
+		"sveltekit-autoimport": "^1.6.9",
 		"vanilla-lazyload": "^17.8.3",
 		"vite": "^3.1.0",
 		"vite-imagetools": "^4.0.9"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,7 @@ specifiers:
   svelte-check: ^2.9.0
   svelte-preprocess: ^4.10.7
   svelte-preprocess-import-assets: ^0.1.6
+  sveltekit-autoimport: ^1.6.9
   vanilla-lazyload: ^17.8.3
   vite: ^3.1.0
   vite-imagetools: ^4.0.9
@@ -78,6 +79,7 @@ devDependencies:
   svelte-check: 2.9.0_shdnsuo55vjluqozcjtxyryg5e
   svelte-preprocess: 4.10.7_shdnsuo55vjluqozcjtxyryg5e
   svelte-preprocess-import-assets: 0.1.6_svelte@3.50.1
+  sveltekit-autoimport: 1.6.9
   vanilla-lazyload: 17.8.3
   vite: 3.1.0_sass@1.54.9
   vite-imagetools: 4.0.9
@@ -3088,6 +3090,15 @@ packages:
   /svelte/3.50.1:
     resolution: {integrity: sha512-bS4odcsdj5D5jEg6riZuMg5NKelzPtmsCbD9RG+8umU03TeNkdWnP6pqbCm0s8UQNBkqk29w/Bdubn3C+HWSwA==}
     engines: {node: '>= 8'}
+    dev: true
+
+  /sveltekit-autoimport/1.6.9:
+    resolution: {integrity: sha512-amnQpqIc24lJqkTP3ak+gItOagjBDMVZQok2JNPm3OeL5z6qMRQumEL7876FNNcpg9XrxmmSr5od/8MP5eBTbQ==}
+    dependencies:
+      '@rollup/pluginutils': 4.2.1
+      estree-walker: 2.0.2
+      magic-string: 0.26.3
+      svelte: 3.50.1
     dev: true
 
   /svg-tags/1.0.0:

--- a/src/content/blog/best-medium-format-camera-for-starting-out/index.md
+++ b/src/content/blog/best-medium-format-camera-for-starting-out/index.md
@@ -13,11 +13,6 @@ categories: ''
 tags: ''
 ---
 
-<script>
-  import ExternalLink from '$lib/components/ExternalLink.svelte';
-  import Link from '$lib/components/Link.svelte';
-</script>
-
 ## What is a Medium Format Camera?
 
 If you are old enough to remember the analogue film camera era, chances are it is the 35&nbsp;mm canisters with the track cut down the side that first come to mind. Shots normally had a 3:2 aspect ratio measuring 36&times;24&nbsp;mm. Medium format film is a whole lot bigger. There is no single prevalent form factor, the film is 60mm across and depending on the camera you can shoot negative frames from 60&times;60 mm to 60 &times; 170 &nbsp;mm. That said 1:1 and roughly 4:5 (from 60 &times; 70 frames) are probably most common. With 35mm film you could nominally get 24 or 36 exposures onto a film. Medium format film is most common in the 120 variety, which lets you shoot 12 exposures. Double length 220 film is less common now. If you do find a roll, you might need to adjust your camera when you load it. Cameras ,like the Pentax 67 have a pressure plate to hold the film flat in the camera. Since 220 film does not have backing paper, it needs a different pressure setting.

--- a/src/content/blog/folding-camera/index.md
+++ b/src/content/blog/folding-camera/index.md
@@ -13,10 +13,6 @@ categories: ''
 tags: ''
 ---
 
-<script>
-  import ExternalLink from '$lib/components/ExternalLink.svelte';
-</script>
-
 ## What is a Folding Camera?
 
 Folding cameras are a well kept secret. Typically the optics are amazing, in fact often better than modern mirrorless and high end DSLR lenses. This is related to the physics, put simply, it is easier to make a good small lens than a large one. On top they are compact, something like the Agfa Isolette can fit into a pocket (they are expensive and quite old cameras so a padded camera bag would be safer!). One drawback is that you cannot usually swap lenses. If you want a halfway-house, try the Mamiya 6. It has a wide angle, normal and telephoto lens, though it does not collapse to as flat a profile as the Isolette.

--- a/src/content/blog/twin-lens-reflex-camera/index.md
+++ b/src/content/blog/twin-lens-reflex-camera/index.md
@@ -13,10 +13,6 @@ categories: ''
 tags: ''
 ---
 
-<script>
-  import ExternalLink from '$lib/components/ExternalLink.svelte';
-</script>
-
 ## What is a Twin Lens Reflex Camera?
 
 Traditionally, the most common type of camera was a Single Lens Reflex camera. Today digital mirrorless cameras are becoming more prevalent. These cameras have an electronic viewfinder which lets you see exactly what will appear in the capture. Things weren't that easy with earlier film cameras. The image needs to be captured on light sensitive film, which must be kept in alight-sealed compartment until you press the shutter release. Since the lens is aligned for capturing your image on the film, you need another way to preview and line up your shot. Single Lens Reflex cameras have view finder, normally at the top of the camera. A mirror inside the camera reflects the image into the viewfinder, deflecting from the film, while you line up your shot. When you fire the shutter, the camera automatically lifts the mirror out of the way before opening the shutter, so that the image can be captured.

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,12 +1,18 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import { imagetools } from 'vite-imagetools';
+import autoImport from 'sveltekit-autoimport';
+
+const autoImportConfig = {
+	components: ['./src/lib/components'],
+	include: ['**/*.svelte', './src/content/blog/**/*.md'],
+};
 
 /** @type {import('vite').UserConfig} */
 const config = {
 	define: {
 		'process.env.VITE_BUILD_TIME': JSON.stringify(new Date().toISOString()),
 	},
-	plugins: [imagetools(), sveltekit()],
+	plugins: [autoImport(autoImportConfig), imagetools(), sveltekit()],
 	server: {
 		port: 5173,
 		strictPort: false,


### PR DESCRIPTION
Blog posts no longer require explicit import of ExternalLink, Link, etc...

# Description

It felt weird and redundant to include `<script>` in the `.md`s for the `ExternalLink` and `Link` components. I love the power of this but would personally prefer to only have to use it for something special, non-standard. Even then, I like the option to configure the imports globally for posts, etc...

## Added Feature

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

`dev`, `build`, and `preview` all produce expected results without error.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Thanks!

Your blog is a great help to me as I deepen my Svelte(+Kit) knowledge. It's fast with advanced image features, plenty for me to learn from. I love how quickly every edit refreshes on the dev side. Thanks for sharing such exemplary code!